### PR TITLE
Render all application properties not just the last one.

### DIFF
--- a/controller/web/template/js/visRenderer.js
+++ b/controller/web/template/js/visRenderer.js
@@ -128,7 +128,7 @@ visRenderer.clickEventListener= function (nodeParams, projectData) {
         let propContent = ""
         for (var pIndex in app.properties) {
             let property = app.properties[pIndex]
-            propContent = `<tr><td>${pIndex}</td><td>${property}</td></tr>`
+            propContent += `<tr><td>${pIndex}</td><td>${property}</td></tr>`
         }
         if (propContent != "") {
             commonTab = commonTab + `<h6>Properties:</h6> <table class="mt-1 table table-sm small"><tbody>${propContent}</tbody></table> `


### PR DESCRIPTION
This is relevant for server mode.

The codes iterates over all application properties correctly but the `propContent` variable get replaced completely in each iteration instead of appending the content.