### PR TITLE
Fix 2nd level odd lines (property section) beeing all the same color …

### DIFF
--- a/templates/documentation/application-properties.tmpl
+++ b/templates/documentation/application-properties.tmpl
@@ -56,7 +56,7 @@
         font-size:0.9rem;
 
     }
-    table tr:nth-child(even) td {
+    table tr:nth-child(even) > td {
     	background: #f3f3f3;
 
     }


### PR DESCRIPTION
…instead of iterating colors.

See screenshot below:
<img width="63" alt="attributes" src="https://user-images.githubusercontent.com/26272469/61058389-6f3c8e80-a3f7-11e9-8dcc-c31e8d42f2d7.png">
