### PR TITLE
Add Markdown parser to Project / Service Description + Field Dependency.Events

### DIFF
--- a/example/templates/htmldocumentation.tmpl
+++ b/example/templates/htmldocumentation.tmpl
@@ -260,6 +260,12 @@
            {{$dependencies := $component.GetAllDependencies }}
            {{ range $dependency := $dependencies }}
                 <li>{{$dependency.Reference}}</li>
+                <ul>
+                {{ range $event := $dependency.Events }}
+                    <li>{{ $event.Name }}</li>
+                {{ end }}
+                </ul>
+
            {{ end }}
        </ul>
         <p>The application requires the following infrastructure services:</p>

--- a/example/templates/htmldocumentation.tmpl
+++ b/example/templates/htmldocumentation.tmpl
@@ -261,7 +261,7 @@
            {{ range $dependency := $dependencies }}
                 <li>{{$dependency.Reference}}</li>
                 <ul>
-                {{ range $event := $dependency.Events }}
+                {{ range $event := $dependency.ConsumedEvents }}
                     <li>{{ $event.Name }}</li>
                 {{ end }}
                 </ul>

--- a/model/core/Application.go
+++ b/model/core/Application.go
@@ -165,7 +165,6 @@ func (a *Application) GetGroupPath() []string {
 	return strings.Split(a.Group, "/")
 }
 
-
 //GetMainGroup - returns the main group
 func (a *Application) GetMainGroup() string {
 	groups := a.GetGroupPath()

--- a/model/core/Dependency.go
+++ b/model/core/Dependency.go
@@ -1,6 +1,11 @@
 package core
 
-import "strings"
+import (
+	"html/template"
+	"strings"
+
+	"github.com/russross/blackfriday"
+)
 
 type Dependency struct {
 	Reference      string            `json:"reference" yaml:"reference"`
@@ -39,4 +44,9 @@ func (Dependency *Dependency) GetServiceName() string {
 func (Dependency *Dependency) GetApplication(Project *Project) (*Application, error) {
 	componentName, _ := Dependency.GetApplicationAndServiceNames()
 	return Project.FindApplication(componentName)
+}
+
+//GetDescriptionHtml - helper that renders the description text as markdown - to be used in HTML documentations
+func (Dependency *Dependency) GetDescriptionHtml() template.HTML {
+	return template.HTML(blackfriday.MarkdownCommon([]byte(Dependency.Description)))
 }

--- a/model/core/Dependency.go
+++ b/model/core/Dependency.go
@@ -7,16 +7,23 @@ import (
 	"github.com/russross/blackfriday"
 )
 
-type Dependency struct {
-	Reference      string            `json:"reference" yaml:"reference"`
-	Description    string            `json:"description" yaml:"description"`
-	Relationship   string            `json:"relationship" yaml:"relationship"`
-	IsSameLevel    bool              `json:"isSameLevel" yaml:"isSameLevel"`
-	IsBrowserBased bool              `json:"isBrowserBased" yaml:"isBrowserBased"`
-	Status         string            `json:"status" yaml:"status"`
-	Properties     map[string]string `json:"properties" yaml:"properties"`
-	IsOptional     bool              `json:"isOptional" yaml:"isOptional"`
-}
+type (
+	Dependency struct {
+		Reference      string            `json:"reference" yaml:"reference"`
+		Description    string            `json:"description" yaml:"description"`
+		Relationship   string            `json:"relationship" yaml:"relationship"`
+		IsSameLevel    bool              `json:"isSameLevel" yaml:"isSameLevel"`
+		IsBrowserBased bool              `json:"isBrowserBased" yaml:"isBrowserBased"`
+		Status         string            `json:"status" yaml:"status"`
+		Properties     map[string]string `json:"properties" yaml:"properties"`
+		IsOptional     bool              `json:"isOptional" yaml:"isOptional"`
+		Events         []DomainEvent     `json:"events" yaml:"events"`
+	}
+
+	DomainEvent struct {
+		Name string `json:"name" yaml:"name"`
+	}
+)
 
 // Returns the name of the "component" and "service" this dependecy points to
 // service might be empty if the dependency just defined the component

--- a/model/core/Dependency.go
+++ b/model/core/Dependency.go
@@ -17,7 +17,7 @@ type (
 		Status         string            `json:"status" yaml:"status"`
 		Properties     map[string]string `json:"properties" yaml:"properties"`
 		IsOptional     bool              `json:"isOptional" yaml:"isOptional"`
-		Events         []Event     `json:"events" yaml:"events"`
+		ConsumedEvents         []Event     `json:"events" yaml:"events"`
 	}
 
 	Event struct {

--- a/model/core/Dependency.go
+++ b/model/core/Dependency.go
@@ -17,10 +17,10 @@ type (
 		Status         string            `json:"status" yaml:"status"`
 		Properties     map[string]string `json:"properties" yaml:"properties"`
 		IsOptional     bool              `json:"isOptional" yaml:"isOptional"`
-		Events         []DomainEvent     `json:"events" yaml:"events"`
+		Events         []Event     `json:"events" yaml:"events"`
 	}
 
-	DomainEvent struct {
+	Event struct {
 		Name string `json:"name" yaml:"name"`
 	}
 )

--- a/model/core/Service.go
+++ b/model/core/Service.go
@@ -1,5 +1,11 @@
 package core
 
+import (
+	"html/template"
+
+	"github.com/russross/blackfriday"
+)
+
 type Service struct {
 	Name          string            `json:"name" yaml:"name"`
 	Title         string            `json:"title" yaml:"title"`
@@ -21,4 +27,9 @@ func (s *Service) HasPropertyWithValue(property string, compareValue string) boo
 		}
 	}
 	return false
+}
+
+//GetDescriptionHtml - helper that renders the description text as markdown - to be used in HTML documentations
+func (s *Service) GetDescriptionHtml() template.HTML {
+	return template.HTML(blackfriday.MarkdownCommon([]byte(s.Description)))
 }


### PR DESCRIPTION
It should be possible to document consumed domain events e.g.

```dependencies:
  - reference: my-fancy--specification-service.events
    relationship: acl
    description: AMQP
    events: 
      - name: AssetCreated
      - name: AssetUpdated