### PR TITLE
Fix nil pointer on missing dependency and output cyclic dependencies

### DIFF
--- a/controller/AnalyzeController.go
+++ b/controller/AnalyzeController.go
@@ -21,7 +21,7 @@ func (a *AnalyzeController) AnalyzeAction() {
 	errors := ProjectAnalyzer.AnalyzeCyclicDependencies(a.project)
 	if errors != nil {
 		for _, error := range errors {
-			fmt.Println(error)
+			log.Println(error)
 		}
 		log.Fatal("Solve Errors please!")
 	}

--- a/model/analyze/ProjectAnalyzer.go
+++ b/model/analyze/ProjectAnalyzer.go
@@ -2,6 +2,7 @@ package analyze
 
 import (
 	"errors"
+	"log"
 	"strconv"
 
 	"github.com/AOEpeople/vistecture/v2/model/core"
@@ -52,10 +53,13 @@ func (projectAnalyzer *ProjectAnalyzer) walkDependencies(project *core.Project, 
 	}
 
 	callStack = append(callStack, component.Name)
-	//Walk Dependcies that are global for the given component
+	//Walk Dependencies that are global for the given component
 	dependencies := component.Dependencies
 	for _, dependency := range dependencies {
 		nextComponent, _ := dependency.GetApplication(project)
+		if nextComponent == nil {
+			log.Fatalf("Could not find dependency \"%s\" for application \"%s\"", dependency.Reference, component.Name)
+		}
 		err := projectAnalyzer.walkDependencies(project, nextComponent, callStack)
 		if err != nil {
 			return err


### PR DESCRIPTION
If a referenced dependency was not declared a nil pointer occurred. Now we output a message helping the user to find out what went wrong.
Also somehow "fmt" does not print all the messages... used "log" to make cyclic dependencies visible