### PR TITLE
Fix broken graphviz font rendering, switch to ttf-freefont

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk add --no-cache \
   graphviz \
-  font-bitstream-type1 \
+  ttf-freefont \
   inotify-tools \
   tini
 COPY build-artifacts/vistecture-linux /usr/local/bin/vistecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN ls -l /app
 FROM alpine:latest
 RUN apk add --no-cache \
   graphviz \
-  font-bitstream-type1 \
+  ttf-freefont \
   inotify-tools \
   tini
 COPY --from=build /app/vistecture /usr/local/bin


### PR DESCRIPTION
Currently, the font-bitstream-type1 font is used for rendering graphs with graphviz, this leads to broken font rendering. By including a different font this issue could be resolved.

**font-bitstream-type1 `dot` output:**
![2021-08-30 at 15 03](https://user-images.githubusercontent.com/3203968/131343624-00ddf9b0-8f07-4b8d-973f-1fe3a5ba4424.png)

**ttf-freefont `dot` output:**
![2021-08-30 at 15 07](https://user-images.githubusercontent.com/3203968/131343735-307ae104-213f-45c9-92e2-edd02b246920.png)
