### PR TITLE
chore: bump npm-audit-action from 1.7.1 to 2.3.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install dependencies
         run: cd controller/web/template && npm ci
-      - uses: oke-py/npm-audit-action@v1.7.1
+      - uses: oke-py/npm-audit-action@v2.3.0
         with:
           audit_level: moderate
           working_directory: controller/web/template/


### PR DESCRIPTION
The check "Frontend NPM dependencies" fails because `npm audit` throws the following error
`Error: npm WARN config production Use --omit=dev instead.`
This problem has already been addressed and fixed in `npm-audit-action` in this commit: https://github.com/oke-py/npm-audit-action/commit/5b91df558179d3eab99d33cb9af44728d21d1fc4

I would suggest to change the version from 1.7.1 to 2.3.0 (latest), which should the issue above.