### PR TITLE
chore: bump nancy from 1.0.1 to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,4 +35,4 @@ jobs:
       - name: WriteGoList
         run: go list -json -m all > go.list
       - name: Nancy
-        uses: sonatype-nexus-community/nancy-github-action@1.0.1
+        uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
When running sonatype-nexus-community/nancy-github-action it always fails with a 500-internal-server error. According to its github page (https://github.com/sonatype-nexus-community/nancy-github-action) the version is not up-tp-date.
I would suggest bumping it up to "main".